### PR TITLE
feat: expose today's courses through content provider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -189,6 +189,12 @@
         </provider>
 
         <provider
+            android:name=".provider.TodayCoursesProvider"
+            android:authorities="${applicationId}.courses"
+            android:exported="true"
+            android:grantUriPermissions="false" />
+
+        <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"

--- a/app/src/main/java/com/haooz/chedule/provider/TodayCoursesProvider.kt
+++ b/app/src/main/java/com/haooz/chedule/provider/TodayCoursesProvider.kt
@@ -1,0 +1,101 @@
+package com.haooz.chedule.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import com.haooz.chedule.data.CourseRepository
+import com.haooz.chedule.reminder.CourseReminderHelper
+
+/** Read-only API for today's active courses. */
+class TodayCoursesProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = context != null
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor {
+        require(uriMatcher.match(uri) == TODAY_COURSES) { "Unsupported URI: $uri" }
+        require(selection == null && selectionArgs == null) { "Selection is not supported" }
+
+        val appContext = requireNotNull(context)
+        val repository = CourseRepository(appContext)
+        val columns = projection?.toList() ?: DEFAULT_COLUMNS
+        require(columns.all { it in DEFAULT_COLUMNS }) { "Unsupported column requested" }
+
+        return MatrixCursor(columns.toTypedArray()).apply {
+            CourseReminderHelper.getTodayCourses(appContext).forEach { course ->
+                val values = mapOf(
+                    COLUMN_ID to course.id,
+                    COLUMN_NAME to course.name,
+                    COLUMN_CLASSROOM to course.classroom,
+                    COLUMN_TEACHER to course.teacher,
+                    COLUMN_START_SECTION to course.startSection,
+                    COLUMN_END_SECTION to course.endSection,
+                    COLUMN_SECTION_TEXT to course.getSectionText(),
+                    COLUMN_START_TIME to CourseReminderHelper.getCourseStartTime(course, repository).orEmpty(),
+                    COLUMN_END_TIME to CourseReminderHelper.getCourseEndTime(course, repository).orEmpty(),
+                )
+                newRow().also { row -> columns.forEach { column -> row.add(values[column]) } }
+            }
+        }
+    }
+
+    override fun getType(uri: Uri): String {
+        require(uriMatcher.match(uri) == TODAY_COURSES) { "Unsupported URI: $uri" }
+        return "vnd.android.cursor.dir/vnd.com.haooz.chedule.course"
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri = unsupportedWrite(uri)
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        unsupportedWrite(uri)
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = unsupportedWrite(uri)
+
+    private fun <T> unsupportedWrite(uri: Uri): T =
+        throw UnsupportedOperationException("$uri is read-only")
+
+    private companion object {
+        const val AUTHORITY = "com.haooz.chedule.courses"
+        const val PATH_TODAY = "today"
+        const val TODAY_COURSES = 1
+
+        const val COLUMN_ID = "id"
+        const val COLUMN_NAME = "name"
+        const val COLUMN_CLASSROOM = "classroom"
+        const val COLUMN_TEACHER = "teacher"
+        const val COLUMN_START_SECTION = "start_section"
+        const val COLUMN_END_SECTION = "end_section"
+        const val COLUMN_SECTION_TEXT = "section_text"
+        const val COLUMN_START_TIME = "start_time"
+        const val COLUMN_END_TIME = "end_time"
+
+        val DEFAULT_COLUMNS = listOf(
+            COLUMN_ID,
+            COLUMN_NAME,
+            COLUMN_CLASSROOM,
+            COLUMN_TEACHER,
+            COLUMN_START_SECTION,
+            COLUMN_END_SECTION,
+            COLUMN_SECTION_TEXT,
+            COLUMN_START_TIME,
+            COLUMN_END_TIME,
+        )
+
+        val uriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+            addURI(AUTHORITY, PATH_TODAY, TODAY_COURSES)
+        }
+    }
+}

--- a/app/src/main/java/com/haooz/chedule/reminder/IslandNotificationHelper.kt
+++ b/app/src/main/java/com/haooz/chedule/reminder/IslandNotificationHelper.kt
@@ -26,6 +26,7 @@ object IslandNotificationHelper {
     private const val TAG = "IslandNotificationHelper"
     private const val CHANNEL_ID = "course_reminder_island"
     private const val CHANNEL_NAME = "课程提醒超级岛"
+    private const val KEY_ISLAND_EXPAND_GLOW_ENABLED = "island_expand_glow_enabled"
     // business: 运营场景标识（官方必选字段）
     private const val BUSINESS_TAG = "course_reminder"
     // 通知更新序号计数器：保证课前→已上课等多次更新不乱序（官方 sequence 字段）
@@ -142,6 +143,7 @@ object IslandNotificationHelper {
 
         // 读取超级岛左侧/右侧显示模式
         val prefs = context.getSharedPreferences("course_reminder_prefs", Context.MODE_PRIVATE)
+        val expandGlowEnabled = prefs.getBoolean(KEY_ISLAND_EXPAND_GLOW_ENABLED, true)
         val leftMode = prefs.getInt("island_left_mode", 0)
         val rightMode = prefs.getInt("island_right_mode", 1)
         val minutesPlus1 = (minutesUntil ?: 0) + 1
@@ -165,6 +167,8 @@ object IslandNotificationHelper {
             put("protocol", 1)
             put("enableFloat", true)
             put("updatable", true)
+            // HyperOS expanded-island glow effect.
+            put("outEffectSrc", if (expandGlowEnabled) "outer_glow" else "")
             // reopen=reopen：课前提醒→已上课切换会重发同 id 通知，需允许再次显示
             put("reopen", "reopen")
             // sequence：每次更新递增，避免课前态/已上课态展示乱序

--- a/app/src/main/java/com/haooz/chedule/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/haooz/chedule/ui/activities/MainActivity.kt
@@ -2,6 +2,7 @@
 package com.haooz.chedule.ui.activities
 
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -178,6 +179,17 @@ class MainActivity : ComponentActivity() {
         @Volatile
         var cachedAppearance: com.haooz.chedule.data.AppearanceConfig =
             com.haooz.chedule.data.AppearanceConfig()
+
+        fun setTaskExcludedFromRecents(context: Context, hidden: Boolean) {
+            if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) return
+            runCatching {
+                val manager = context.getSystemService(ActivityManager::class.java)
+                val appTask = manager.appTasks.firstOrNull { task ->
+                    task.taskInfo?.baseIntent?.component?.packageName == context.packageName
+                } ?: manager.appTasks.firstOrNull()
+                appTask?.setExcludeFromRecents(hidden)
+            }
+        }
     }
 
     var shareIntentUri: android.net.Uri? = null
@@ -207,8 +219,17 @@ class MainActivity : ComponentActivity() {
         isInFreeformWindow = isInMultiWindowMode
     }
 
+    fun applyHideFromRecents(hidden: Boolean) {
+        setTaskExcludedFromRecents(this, hidden)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        applyHideFromRecents(
+            getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+                .getBoolean("hide_background", false)
+        )
 
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.light(
@@ -293,6 +314,17 @@ class MainActivity : ComponentActivity() {
         handleReminderSettingsIntent(intent)
         // 更新版本号触发 Compose 重组
         shareIntentVersion++
+    }
+
+    override fun onBackPressed() {
+        val hideBackground = getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            .getBoolean("hide_background", false)
+        if (hideBackground) {
+            applyHideFromRecents(true)
+            moveTaskToBack(true)
+            return
+        }
+        super.onBackPressed()
     }
 
     private fun handleReminderSettingsIntent(intent: Intent?) {

--- a/app/src/main/java/com/haooz/chedule/ui/activities/PreferenceSettingsScreen.kt
+++ b/app/src/main/java/com/haooz/chedule/ui/activities/PreferenceSettingsScreen.kt
@@ -64,6 +64,15 @@ fun PreferenceSettingsScreen(
 
     val settingsViewModel = remember { SettingsViewModel(context.applicationContext as android.app.Application) }
     val defaultHomepage by settingsViewModel.defaultHomepage.collectAsState()
+    val islandNotification by settingsViewModel.islandNotification.collectAsState()
+    val reminderPrefs = remember { context.getSharedPreferences("course_reminder_prefs", Context.MODE_PRIVATE) }
+    var islandExpandGlowEnabled by remember {
+        mutableStateOf(reminderPrefs.getBoolean("island_expand_glow_enabled", true))
+    }
+    val appPrefs = remember { context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE) }
+    var hideBackground by remember {
+        mutableStateOf(appPrefs.getBoolean("hide_background", false))
+    }
 
     val isTablet = LocalConfiguration.current.screenWidthDp >= 600
     val tabletHorizontalPadding = if (isTablet) {
@@ -173,6 +182,17 @@ fun PreferenceSettingsScreen(
                                 checked = todayShowWallpaper,
                                 onCheckedChange = { settingsViewModel.setTodayShowWallpaper(it) }
                             )
+                            if (islandNotification) {
+                                SwitchPreference(
+                                    title = "超级岛展开态发光",
+                                    summary = "在小米超级岛展开时显示系统发光效果",
+                                    checked = islandExpandGlowEnabled,
+                                    onCheckedChange = {
+                                        islandExpandGlowEnabled = it
+                                        reminderPrefs.edit { putBoolean("island_expand_glow_enabled", it) }
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -230,6 +250,16 @@ fun PreferenceSettingsScreen(
                         insideMargin = PaddingValues(0.dp)
                     ) {
                         Column(modifier = Modifier.fillMaxWidth()) {
+                            SwitchPreference(
+                                title = "隐藏后台",
+                                summary = "返回主页时退到后台，并隐藏最近任务卡片",
+                                checked = hideBackground,
+                                onCheckedChange = {
+                                    hideBackground = it
+                                    appPrefs.edit { putBoolean("hide_background", it) }
+                                    MainActivity.setTaskExcludedFromRecents(context, it)
+                                }
+                            )
                             val repoEntry = DropdownEntry(
                                 items = listOf(
                                     DropdownItem(


### PR DESCRIPTION
## Summary
- Add a public, read-only content://com.haooz.chedule.courses/today provider for today's active courses.
- Add the Super Island expanded glow preference and HyperOS outer_glow field.
- Add a hide-background preference that excludes the app task from recents.

## Verification
- :app:assembleDebug
- Queried content://com.haooz.chedule.courses/today on a connected Android device.