### PR TITLE
对表格视图中的课程教室信息显示进行优化

### DIFF
--- a/app/src/main/java/com/haooz/chedule/ui/components/CourseCard.kt
+++ b/app/src/main/java/com/haooz/chedule/ui/components/CourseCard.kt
@@ -406,17 +406,26 @@ private fun CardContent(course: Course, sectionCount: Int, textColor: Color, has
     val infoFontSize = 11.sp
     val infoLineHeight = 12.sp
     val courseNameLineHeight = 14.2.sp
+    val courseNameFontSize = 12.7.sp
 
-    val showClassroom = sectionCount >= 2 && course.classroom.isNotEmpty()
-    val showTeacher = sectionCount >= 2 && course.teacher.isNotEmpty()
+    // 教室显示判断：不再根据课程节数判断；卡片高度 >= 70dp 时显示教室
+    val showClassroom = course.classroom.isNotBlank() && cardHeightDp >= 69.5f
+    // 教师显示判断：保持不变（节数 >= 2 且教师非空）
+    val showTeacher = sectionCount >= 2 && course.teacher.isNotBlank()
 
     // 课程名称最多行数：卡片高度能放下几行就几行
+    // 当卡片高度 >= 70dp 时课程名称最多占 2 行以保证教室显示；当 >= 92dp 时最多占 3 行（或按卡片剩余高度计算）
     val density = LocalDensity.current
     val availableHeightDp = cardHeightDp - 16f
     val courseNameLineH = with(density) { courseNameLineHeight.toDp().value }
     val infoLineH = with(density) { infoLineHeight.toDp().value }
     val reservedForInfo = ((if (showClassroom) 1 else 0) + (if (showTeacher) 1 else 0)) * infoLineH
-    val nameMaxLines = ((availableHeightDp - reservedForInfo) / courseNameLineH).toInt().coerceAtLeast(1)
+    val calculatedMaxLines = ((availableHeightDp - reservedForInfo) / courseNameLineH).toInt().coerceAtLeast(1)
+    val nameMaxLines = when {
+        cardHeightDp >= 91.5f -> calculatedMaxLines.coerceAtMost(3).coerceAtLeast(1)
+        cardHeightDp >= 69.5f -> calculatedMaxLines.coerceAtMost(2).coerceAtLeast(1)
+        else -> calculatedMaxLines
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         val verticalArrangement = when (cardContentAlignment) {
@@ -448,7 +457,7 @@ private fun CardContent(course: Course, sectionCount: Int, textColor: Color, has
             Text(
                 text = course.name,
                 fontWeight = FontWeight.Bold,
-                fontSize = 12.7.sp,
+                fontSize = courseNameFontSize,
                 lineHeight = courseNameLineHeight,
                 color = textColor,
                 textAlign = textAlign,


### PR DESCRIPTION
移除教室显示对课程节数（sectionCount >= 2）的强制限制，支持单节课程展示教室信息
支持根据卡片实际高度动态分配空间并展示教室信息：卡片高度 >= 70dp：课程名称最多分配 2 行并展示教室；卡片高度 >= 92dp：课程名称最多分配 3 行并展示教室
保持教师信息的节数限制逻辑不变（仍需 >= 2 节才显示）